### PR TITLE
Add an implementation of finding the longest common prefix of an array of strings

### DIFF
--- a/Java/LargestCommonPrefix.java
+++ b/Java/LargestCommonPrefix.java
@@ -1,0 +1,41 @@
+/* Author : Shuyin Liu
+ * Problem : To find the longest common prefix string amongst an array of strings, input on command line.
+ * Explanation : Sample command --  java LongestCommonPrefix apple application appointment
+ */
+class LongestCommonPrefix {
+    public static void main(String[] args) {
+        System.out.print("The common prefix is:");
+        if (args.length == 0) {
+            System.out.println("");
+            return;
+        }
+        if (args.length == 1) {
+            System.out.println(args[0]);
+            return;
+        }
+
+        String prev = args[0];
+
+        for (int i = 1; i < args.length; i++) {
+            prev = getCommonPrefix(prev, args[i]);
+            if (prev.isEmpty()) {
+                System.out.println("");
+                return;
+            }
+        }
+
+        System.out.println(prev);
+    }
+
+    private static String getCommonPrefix(String a, String b) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < a.length() && i < b.length(); i++) {
+            if (a.charAt(i) == b.charAt(i)) {
+                sb.append(a.charAt(i));
+            } else {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Print out empty string if there is no common prefix. I aim this to be counted towards the Hacktoberfest. Thank you!

## Summary by Sourcery

Implement a Java command-line utility that finds and prints the longest common prefix among given string arguments, defaulting to an empty string when there are no inputs or no shared prefix.

New Features:
- Add LongestCommonPrefix.java to compute and output the longest common prefix of command-line arguments, handling zero or single argument cases by printing an empty string or the lone argument.
- Use iterative pairwise comparison with a helper method to build the common prefix across all inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to compute the longest common prefix across multiple text inputs
  * Handles edge cases efficiently, including scenarios with no common prefix or single inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->